### PR TITLE
Refresh Spotify API token, if response says that the token has expired

### DIFF
--- a/src/main/java/me/dreamhopping/mediamod/media/core/api/MediaInfo.java
+++ b/src/main/java/me/dreamhopping/mediamod/media/core/api/MediaInfo.java
@@ -12,5 +12,25 @@ public class MediaInfo {
 
     @SerializedName("item")
     public Track track;
+
+    @SerializedName("error")
+    public SpotifyError error;
+
+    public static class SpotifyError extends Exception {
+        @SerializedName("status")
+        public final int status;
+        @SerializedName("message")
+        public final String message;
+
+        SpotifyError(int status, String message) {
+            this.status = status;
+            this.message = message;
+        }
+
+        @Override
+        public String toString() {
+            return "Spotify error: status=" + status +", message='" + message+"'";
+        }
+    }
 }
 

--- a/src/main/java/me/dreamhopping/mediamod/media/services/spotify/SpotifyService.java
+++ b/src/main/java/me/dreamhopping/mediamod/media/services/spotify/SpotifyService.java
@@ -294,6 +294,14 @@ class SpotifyAPI {
             MediaMod.INSTANCE.logger.error("An error occurred when getting playback info: ", e);
         }
 
+        if (info != null && info.error != null) {
+            if (info.error.status == 401 && info.error.message.equals("The access token expired")) {
+                this.refresh();
+            } else {
+                MediaMod.INSTANCE.logger.error("Spotify gave an error when getting playback info: ", info.error);
+            }
+        }
+
         return info;
     }
 


### PR DESCRIPTION
Currently MediaMod stops working (like [this](https://cdn.discordapp.com/attachments/681075622013042743/772524312573378571/unknown.png)) after about an hour with Spotify.
This happens, because the spotify token expires and MediaMod doesn't refresh the token. With this commit, MediaMod will refresh the token if it gets an error that the token has expired.

If this does not fit in, let me know with possible suggestions.